### PR TITLE
Upgrade and release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- [#10](https://github.com/embedded-graphics/tinybmp/pull/10) Bump embedded-graphics minimum version from 0.7.0 to 0.7.1
+
 ## [0.4.0] - 2021-06-06
 
 ## [0.4.0-beta.1] - 2021-05-24
@@ -105,10 +107,10 @@
 - [#218](https://github.com/embedded-graphics/embedded-graphics/pull/218) Test README examples in CI and update them to work with latest crate versions.
 
 <!-- next-url -->
+
 [unreleased]: https://github.com/embedded-graphics/tinytga/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/embedded-graphics/tinytga/compare/v0.4.0-beta.1...v0.4.0
 [0.4.0-beta.1]: https://github.com/embedded-graphics/tinytga/compare/v0.4.0-alpha.1...v0.4.0-beta.1
-
 [0.4.0-alpha.1]: https://github.com/embedded-graphics/tinytga/compare/after-split...v0.4.0-alpha.1
 [0.4.0-alpha.1 - `embedded-graphics` repository]: https://github.com/embedded-graphics/embedded-graphics/compare/tinytga-v0.3.2...before-split
 [0.3.2]: https://github.com/embedded-graphics/embedded-graphics/compare/tinytga-v0.3.0...tinytga-v0.3.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 circle-ci = { repository = "embedded-graphics/tinytga", branch = "master" }
 
 [dependencies]
-embedded-graphics = "0.7.0"
+embedded-graphics = "0.7.1"
 nom = { version = "6.0.1", default-features = false }
 
 [dev-dependencies]

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -1,0 +1,62 @@
+# Release process
+
+Target audience: crate maintainers who wish to release `tinytga`.
+
+> Please take a cautious approach to this. If any step doesn't feel right or doesn't succeed smoothly, stop and rectify any issues before continuing.
+
+## On GitHub
+
+- Check that all desired PRs are merged and all desired issues are closed/resolved.
+- Check that the latest master build passed in CircleCI.
+
+## On your local machine
+
+- `cd` to the repository root
+- Check that `cargo-release` is installed and available in `$PATH`:
+
+  ```bash
+  cargo release --version
+  ```
+
+- Ensure you have the latest changes with `git switch master` and `git pull --rebase`
+- Check that your local repository is clean with no uncommitted changes and no unpushed commits. Ideally, use `git reset --hard origin/master` to ensure your local state is up to date with `origin/master`. You may need to change `origin` to the name of the remote pointing to <https://github.com/embedded-graphics/tinytga>.
+- Before a **stable** release:
+  - Search the repository for any `TODO` or `FIXME` comments. If any need resolving before release, stop this process and fix them with one or more PRs.
+- Check that the crate version in `Cargo.toml` matches the latest released versions on <https://crates.io/crates/tinytga>.
+- Run `just build` to ensure the build passes locally.
+  - If the build fails for any reason, stop the release process and fix any issues by creating PRs. The upstream master branch must remain the source of truth. Restart this checklist once `just build` passes.
+- Double check the release level (major, minor, patch)
+- Release the crate:
+
+  ```bash
+  cargo release <level>
+  ```
+
+  Where `<level>` is `major`, `minor`, `patch`, or a specific SemVer version number.
+
+## Post release
+
+- Check that the release command pushed a Git tag when the crate was published, something like `v0.4.0-beta.1` or `v0.3.1`.
+- For the new tag, go to its page at e.g. <https://github.com/embedded-graphics/tinytga/releases/tag/v0.4.0-beta.1>, click <kbd>Edit tag</kbd> and draft a release:
+
+  - Copy and paste the tag into the `Release title` field.
+  - Copy and paste the latest released section out of the crate's `CHANGELOG.md` file into the `Describe this release` field. Do not include the version header, e.g.:
+
+    ```markdown
+    ### Added
+
+    - [#111](https://github.com/embedded-graphics/tinytga/pull/111) Added something
+
+    ### Removed
+
+    - [#222](https://github.com/embedded-graphics/tinytga/pull/222) Removed a thing
+    ```
+
+  - For `alpha` or `beta` releases, check the `This is a pre-release` checkbox.
+  - Hit <kbd>Publish release</kbd>
+
+- Check that the release is displayed on the [repository homepage](https://github.com/embedded-graphics/tinytga).
+- Post a link to the released tag (e.g. <https://github.com/embedded-graphics/tinytga/releases/tag/v0.4.0-beta.1>) to the embedded-graphics Matrix room at <https://matrix.to/#/!SfJCDXZbMHXkPovtKL:matrix.org>
+- If you are @jamwaffles, post a Tweet tagging @rustembedded with a happy announcement message.
+
+- Check the other repositories in the [embedded-graphics organization](https://github.com/embedded-graphics) for dependencies on `tinytga`. The version should be updated to the latest releases made whilst following this guide.


### PR DESCRIPTION
Thank you for helping out with tinytga development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Upgrades e-g to 0.7.1 and adds a copypasta/draft releasing document. As the release doc is an almost verbatim copy of the one added in embedded-graphics/simulator#35, there may be some changes there that we want to add here too when that PR is merged. To that end, I can either split the release doc addition into a separate PR to leave open, or we can merge this PR as is now and fix-forward the doc later.
