### PR TITLE
Replace CI badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,8 @@ readme = "./README.md"
 license = "MIT OR Apache-2.0"
 exclude = [
     "/.github/",
-    "/.circleci/",
     ".gitignore",
 ]
-
-[badges]
-circle-ci = { repository = "embedded-graphics/tinytga", branch = "master" }
 
 [[bench]]
 name = "draw"
@@ -31,4 +27,4 @@ nom = { version = "7.1.1", default-features = false }
 paste = "1.0"
 criterion = "0.3.5"
 clap = { version = "3.2.22", features = ["derive"] }
-embedded-graphics-simulator = { version = "0.5.0", default_features = false }
+embedded-graphics-simulator = { version = "0.5.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TinyTGA
 
-[![Build Status](https://circleci.com/gh/embedded-graphics/tinytga/tree/master.svg?style=shield)](https://circleci.com/gh/embedded-graphics/tinytga/tree/master)
+[![CI Status](https://github.com/embedded-graphics/tinytga/actions/workflows/ci.yml/badge.svg)](https://github.com/embedded-graphics/tinytga/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/tinytga.svg)](https://crates.io/crates/tinytga)
 [![Docs.rs](https://docs.rs/tinytga/badge.svg)](https://docs.rs/tinytga)
 [![embedded-graphics on Matrix](https://img.shields.io/matrix/rust-embedded-graphics:matrix.org)](https://matrix.to/#/#rust-embedded-graphics:matrix.org)

--- a/README.tpl
+++ b/README.tpl
@@ -1,6 +1,6 @@
 # TinyTGA
 
-[![Build Status](https://circleci.com/gh/embedded-graphics/tinytga/tree/master.svg?style=shield)](https://circleci.com/gh/embedded-graphics/tinytga/tree/master)
+[![CI Status](https://github.com/embedded-graphics/tinytga/actions/workflows/ci.yml/badge.svg)](https://github.com/embedded-graphics/tinytga/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/tinytga.svg)](https://crates.io/crates/tinytga)
 [![Docs.rs](https://docs.rs/tinytga/badge.svg)](https://docs.rs/tinytga)
 [![embedded-graphics on Matrix](https://img.shields.io/matrix/rust-embedded-graphics:matrix.org)](https://matrix.to/#/#rust-embedded-graphics:matrix.org)

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -7,7 +7,7 @@ Target audience: crate maintainers who wish to release `tinytga`.
 ## On GitHub
 
 - Check that all desired PRs are merged and all desired issues are closed/resolved.
-- Check that the latest master build passed in CircleCI.
+- Check that the latest master build passed in all CI checks.
 
 ## On your local machine
 


### PR DESCRIPTION
This PR finishes the transition to GitHub Actions by replacing the CI badge and removing the remaining mentions of CircleCI.
